### PR TITLE
Use Module#module_parent_name for Rails6

### DIFF
--- a/aws-xray.gemspec
+++ b/aws-xray.gemspec
@@ -35,6 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'sentry-raven'
   spec.add_development_dependency 'simplecov'
-  spec.add_development_dependency 'sqlite3', '~> 1.3.6'
+  spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'webmock'
 end

--- a/lib/aws/xray/rails.rb
+++ b/lib/aws/xray/rails.rb
@@ -5,7 +5,13 @@ module Aws
     class Railtie < ::Rails::Railtie
       initializer 'aws-xray.set_name' do |app|
         unless Aws::Xray.config.name
-          app_name = app.class.parent_name.underscore.gsub(/(\/|_)/, '-')
+          klass = app.class
+          parent_name = if klass.respond_to?(:module_parent_name)
+              klass.module_parent_name
+            else
+              klass.parent_name
+            end
+          app_name = parent_name.underscore.gsub(/(\/|_)/, '-')
 
           if Rails.env.production?
             Aws::Xray.config.name = app_name


### PR DESCRIPTION
This PR suppresses DEPRECATION WARNING caused by [the changes on rails6](https://github.com/rails/rails/pull/34051) .

please review this 🙏 👀 @cookpad/infra 
cc/ @taiki45 