### PR TITLE
Require stringio explicitly for Ruby >= 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ branches:
   only:
     - master
 rvm:
-  - 2.4
-  - 2.5
   - 2.6
+  - 2.7
+  - 3.0

--- a/aws-xray.gemspec
+++ b/aws-xray.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'coveralls'
   spec.add_development_dependency 'faraday'
+  spec.add_development_dependency 'irb'
   spec.add_development_dependency 'json-schema'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'rack-test'

--- a/lib/aws/xray/sockets.rb
+++ b/lib/aws/xray/sockets.rb
@@ -1,3 +1,5 @@
+require 'stringio'
+
 module Aws
   module Xray
     # For test


### PR DESCRIPTION
```
% RBENV_VERSION=2.6.6 bundle exec ruby -e "require 'aws/xray/sockets'"
% RBENV_VERSION=2.7.2 bundle exec ruby -e "require 'aws/xray/sockets'"
Traceback (most recent call last):
        4: from -e:1:in `<main>'
        3: from -e:1:in `require'
        2: from /home/eagletmt/.clg/github.com/cookpad/aws-xray/lib/aws/xray/sockets.rb:1:in `<top (required)>'
        1: from /home/eagletmt/.clg/github.com/cookpad/aws-xray/lib/aws/xray/sockets.rb:2:in `<module:Aws>'
/home/eagletmt/.clg/github.com/cookpad/aws-xray/lib/aws/xray/sockets.rb:12:in `<module:Xray>': uninitialized constant StringIO (NameError)
```