### PR TITLE
Support sentry-ruby gem in ErrorHandlerWithSentry

### DIFF
--- a/aws-xray.gemspec
+++ b/aws-xray.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rsolr'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'sentry-raven'
+  spec.add_development_dependency 'sentry-ruby'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'sqlite3'
   spec.add_development_dependency 'webmock'

--- a/lib/aws/xray/error_handlers.rb
+++ b/lib/aws/xray/error_handlers.rb
@@ -21,16 +21,24 @@ Error: #{error}
       end
     end
 
-    # Must be configured sentry-raven gem.
+    # Must be configured sentry-raven or sentry-ruby gem.
     class ErrorHandlerWithSentry
       ERROR_LEVEL = 'warning'.freeze
 
       def call(error, payload, host:, port:)
-        ::Raven.capture_exception(
-          error,
-          level: ERROR_LEVEL,
-          extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
-        )
+        if defined?(::Sentry)
+          ::Sentry.capture_exception(
+            error,
+            level: ERROR_LEVEL,
+            extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
+          )
+        elsif defined?(::Raven)
+          ::Raven.capture_exception(
+            error,
+            level: ERROR_LEVEL,
+            extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
+          )
+        end
       end
     end
   end

--- a/lib/aws/xray/error_handlers.rb
+++ b/lib/aws/xray/error_handlers.rb
@@ -23,22 +23,32 @@ Error: #{error}
 
     # Must be configured sentry-raven or sentry-ruby gem.
     class ErrorHandlerWithSentry
+      class MissingSentryError < StandardError; end
+
+      def initialize
+        if !defined?(::Sentry) && !defined?(::Raven)
+          raise MissingSentryError.new('Must be installed sentry-raven or sentry-ruby gem')
+        end
+      end
+
       ERROR_LEVEL = 'warning'.freeze
 
       def call(error, payload, host:, port:)
-        if defined?(::Sentry)
-          ::Sentry.capture_exception(
-            error,
-            level: ERROR_LEVEL,
-            extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
-          )
-        elsif defined?(::Raven)
+        if defined?(::Raven)
           ::Raven.capture_exception(
             error,
             level: ERROR_LEVEL,
             extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
           )
+
+          return
         end
+
+        ::Sentry.capture_exception(
+          error,
+          level: ERROR_LEVEL,
+          extra: { 'payload' => payload, 'payload_raw' => payload.unpack('H*').first }
+        )
       end
     end
   end


### PR DESCRIPTION
Support `sentry-ruby` gem in ErrorHandlerWithSentry when `sentry-ruby` gem is installed instead of `sentry-raven` gem.

@cookpad/infra Please review.